### PR TITLE
Catch errors caused by malformed incoming packets

### DIFF
--- a/src/Server.ts
+++ b/src/Server.ts
@@ -50,7 +50,11 @@ export class Server extends EventEmitter {
     this.socket.on('message', (buffer, rinfo) => {
       this.inLog('[C->S]', buffer, rinfo)
       const sender = new InetAddress(rinfo.address, rinfo.port)
-      this.handle(buffer, sender)
+      try{
+        this.handle(buffer, sender)
+      }catch (e) {
+        this.emit('incomingPacketError', e, buffer)
+      }
     })
 
     await new Promise((resolve, reject) => {


### PR DESCRIPTION
Currently, unknown/malformed incoming packets will result in an error that is never caught, causing applications based on the library to crash.
This pull request catches those errors and emits them as an event of the Server object.